### PR TITLE
fix unflatten

### DIFF
--- a/modular_rl/misc_utils.py
+++ b/modular_rl/misc_utils.py
@@ -157,6 +157,7 @@ def unflatten(vec, shapes):
         size = np.prod(shape)
         arr = vec[i:i+size].reshape(shape)
         arrs.append(arr)
+        i += size
     return arrs
 
 class EzPickle(object):


### PR DESCRIPTION
This can be reproduced with

```
import numpy as np
from modular_rl import *
thetas = [np.array([1, 2]), np.array([3, 4])]
unflatten(flatten(thetas), [(2,), (2,)])
```

gives (before the fix):

```
[array([1, 2]), array([1, 2])]
```

and after the fix:

```
[array([1, 2]), array([3, 4])]
```
