### PR TITLE
Replaced calls to `env.monitor.start`, which is deprecated.

### DIFF
--- a/run_pg.py
+++ b/run_pg.py
@@ -13,7 +13,7 @@ import gym
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    update_argument_parser(parser, GENERAL_OPTIONS)    
+    update_argument_parser(parser, GENERAL_OPTIONS)
     parser.add_argument("--env",required=True)
     parser.add_argument("--agent",required=True)
     parser.add_argument("--plot",action="store_true")
@@ -23,12 +23,12 @@ if __name__ == "__main__":
     mondir = args.outfile + ".dir"
     if os.path.exists(mondir): shutil.rmtree(mondir)
     os.mkdir(mondir)
-    env.monitor.start(mondir, video_callable=None if args.video else VIDEO_NEVER)
+    env = gym.wrappers.Monitor(env, mondir, video_callable=None if args.video else VIDEO_NEVER)
     agent_ctor = get_agent_cls(args.agent)
     update_argument_parser(parser, agent_ctor.options)
     args = parser.parse_args()
-    if args.timestep_limit == 0: 
-        args.timestep_limit = env_spec.timestep_limit    
+    if args.timestep_limit == 0:
+        args.timestep_limit = env_spec.timestep_limit
     cfg = args.__dict__
     np.random.seed(args.seed)
     agent = agent_ctor(env.observation_space, env.action_space, cfg)
@@ -39,7 +39,7 @@ if __name__ == "__main__":
     COUNTER = 0
     def callback(stats):
         global COUNTER
-        COUNTER += 1  
+        COUNTER += 1
         # Print stats
         print "*********** Iteration %i ****************" % COUNTER
         print tabulate(filter(lambda (k,v) : np.asarray(v).size==1, stats.items())) #pylint: disable=W0110
@@ -51,7 +51,7 @@ if __name__ == "__main__":
                 else:
                     assert val.ndim == 1
                     diagnostics[stat].extend(val)
-            if args.snapshot_every and ((COUNTER % args.snapshot_every==0) or (COUNTER==args.n_iter)): 
+            if args.snapshot_every and ((COUNTER % args.snapshot_every==0) or (COUNTER==args.n_iter)):
                 hdf['/agent_snapshots/%0.4i'%COUNTER] = np.array(cPickle.dumps(agent,-1))
         # Plot
         if args.plot:
@@ -63,5 +63,4 @@ if __name__ == "__main__":
         hdf['env_id'] = env_spec.id
         try: hdf['env'] = np.array(cPickle.dumps(env, -1))
         except Exception: print "failed to pickle env" #pylint: disable=W0703
-    
-    env.monitor.close()
+    env.close()


### PR DESCRIPTION
# Expected behaviour

Running the command

    python run_pg.py --gamma=0.995 --lam=0.97 --agent=modular_rl.agentzoo.TrpoAgent --max_kl=0.01 --cg_damping=0.1 --activation=tanh --n_iter=250 --seed=0 --timesteps_per_batch=40000 --env=AirRaid-ram-v0 --outfile=./AirRaid-ram-v0.h5

Works without any errors.

# Actual behaviour

Python raises a 

    gym.error.Error: env.monitor has been deprecated as of 12/23/2016. Remove your call to `env.monitor.start(directory)` and instead wrap your env with `env = gym.wrappers.Monitor(env, directory)` to record data.

# Steps to reproduce

1. Follow the installation instructions. 

# Fix 

Replace the call to `env.monitor` with a call to `gym.wrappers.Monitor`. See PR.